### PR TITLE
Fix to allow later environment to access rbac_version

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -77,7 +77,9 @@ jobs:
 
   test:
     uses: ./.github/workflows/deploy.yml
-    needs: delius-core-dev
+    needs:
+      - release
+      - delius-core-dev
     with:
       environment: delius-test
       environment_url: https://ndelius.test.probation.service.justice.gov.uk/
@@ -107,7 +109,9 @@ jobs:
 
   stage:
     uses: ./.github/workflows/deploy.yml
-    needs: delius-core-dev
+    needs:
+      - release
+      - delius-core-dev
     with:
       environment: delius-stage
       environment_url: https://ndelius.stage.probation.service.justice.gov.uk/
@@ -152,6 +156,7 @@ jobs:
   training:
     uses: ./.github/workflows/deploy.yml
     needs:
+      - release
       - serenity-tests
 #      - performance-tests
     with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -144,6 +144,7 @@ jobs:
   pre-prod:
     uses: ./.github/workflows/deploy.yml
     needs:
+      - release
       - serenity-tests
 #      - performance-tests
     with:


### PR DESCRIPTION
Made each environment dependent on the `release` job so that they can access `needs.release.outputs.rbac_version`.
